### PR TITLE
Add changelogs page

### DIFF
--- a/changelogs/index.html
+++ b/changelogs/index.html
@@ -66,7 +66,9 @@
                     <li class="nav-item">
                         <a class="nav-link" href="/faq">FAQ</a>
                     </li>
-                    <li class="nav-item active">Changelogs <span class="sr-only">(current)</span></li>
+                    <li class="nav-item active">
+                        <a class="nav-link">Changelogs <span class="sr-only">(current)</span></a>
+                    </li>
                 </ul>
                 <span class="navbar-text">
                     <a href="https://www.patreon.com/bePatron?u=21831307" style="height:37px"
@@ -89,6 +91,9 @@
         </section>
 
         <section class="text-center">
+            <h3>Changelogs</h3>
+            <p>Below can you find the current Changelogs of 5zig.</p>
+            
             <h3><a href="3.13.0">3.13.0</a></h3>
             <h3><a href="3.14.0">3.14.0</a></h3>
         </section>

--- a/changelogs/index.html
+++ b/changelogs/index.html
@@ -1,0 +1,116 @@
+<!doctype html>
+<html lang="en">
+
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+    <meta name="description" content="All-in-one modification for Minecraft 1.8.9-1.15.2">
+    <meta name="author" content="5zig Reborn">
+    <title>Changelogs | 5zig Reborn</title>
+
+    <link rel="canonical" href="https://5zigreborn.eu/">
+
+    <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.6.3/css/brands.css"
+        integrity="sha384-1KLgFVb/gHrlDGLFPgMbeedi6tQBLcWvyNUN+YKXbD7ZFbjX6BLpMDf0PJ32XJfX" crossorigin="anonymous">
+    <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.6.3/css/fontawesome.css"
+        integrity="sha384-jLuaxTTBR42U2qJ/pm4JRouHkEDHkVqH0T1nyQXn1mZ7Snycpf6Rl25VBNthU4z0" crossorigin="anonymous">
+    <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.8.1/css/solid.css"
+        integrity="sha384-QokYePQSOwpBDuhlHOsX0ymF6R/vLk/UQVz3WHa6wygxI5oGTmDTv8wahFOSspdm" crossorigin="anonymous">
+    <link rel="stylesheet" href="../patreon.css">
+
+    <!-- Bootstrap core CSS -->
+    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css"
+        integrity="sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T" crossorigin="anonymous">
+
+    <style>
+        .bd-placeholder-img {
+            font-size: 1.125rem;
+            text-anchor: middle;
+            -webkit-user-select: none;
+            -moz-user-select: none;
+            -ms-user-select: none;
+            user-select: none;
+        }
+
+        @media (min-width: 768px) {
+            .bd-placeholder-img-lg {
+                font-size: 3.5rem;
+            }
+        }
+    </style>
+</head>
+
+<body>
+    <header>
+        <nav class="navbar navbar-expand-lg navbar-dark bg-dark">
+            <a class="navbar-brand" href="#">5zig Reborn</a>
+            <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarSupportedContent"
+                aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
+                <span class="navbar-toggler-icon"></span>
+            </button>
+
+            <div class="collapse navbar-collapse" id="navbarSupportedContent">
+                <ul class="navbar-nav mr-auto">
+                    <li class="nav-item">
+                        <a class="nav-link" href="/">Home</a>
+                    </li>
+                    <li class="nav-item">
+                        <a class="nav-link" href="/downloads/">Downloads</a>
+                    </li>
+                    <li class="nav-item">
+                        <a class="nav-link" href="https://secure.5zigreborn.eu/panel">Panel</a>
+                    </li>
+                    <li class="nav-item">
+                        <a class="nav-link" href="https://status.5zigreborn.eu">Status</a>
+                    </li>
+                    <li class="nav-item">
+                        <a class="nav-link" href="/faq">FAQ</a>
+                    </li>
+                    <li class="nav-item active">Changelogs <span class="sr-only">(current)</span></li>
+                </ul>
+                <span class="navbar-text">
+                    <a href="https://www.patreon.com/bePatron?u=21831307" style="height:37px"
+                        data-patreon-widget-type="become-patron-button">Become a
+                        Patron!</a>
+                    <script async src="https://c6.patreon.com/becomePatronButton.bundle.js"></script>
+                </span>
+            </div>
+        </nav>
+    </header>
+
+    <main role="main">
+
+        <section class="jumbotron text-center">
+            <div class="container">
+                <h1 class="jumbotron-heading">The 5zig Mod - Changelogs</h1>
+                <p class="lead text-muted">All-in-one modification for Minecraft 1.8.9-1.15.2. <br>
+                    Revamp the way you play the game!</p>
+            </div>
+        </section>
+
+        <section class="text-center">
+            <h3><a href="3.13.0">3.13.0</a></h3>
+            <h3><a href="3.14.0">3.14.0</a></h3>
+        </section>
+    </main>
+
+    <footer class="text-muted">
+        <div class="container">
+            <p class="float-right">
+                <a href="#">Back to top</a>
+            </p>
+            <p>&copy; 2019-2020 5zig Reborn</p>
+            <p>Most of the project is licensed under the <i class="fas fa-balance-scale"></i> <a
+                    href="https://www.gnu.org/licenses/gpl-3.0">GNU General Public License version 3.0</a>.</p>
+        </div>
+    </footer>
+    <script src="https://code.jquery.com/jquery-3.3.1.slim.min.js"
+        integrity="sha384-q8i/X+965DzO0rT7abK41JStQIAqVgRVzpbzo5smXKp4YfRvH+8abtTE1Pi6jizo"
+        crossorigin="anonymous"></script>
+    <script>window.jQuery || document.write('<script src="/docs/4.3/assets/js/vendor/jquery-slim.min.js"><\/script>')</script>
+    <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.bundle.min.js"
+        integrity="sha384-xrRywqdh3PHs8keKZN+8zzc5TX0GRTLCcmivcbNJWm2rs5C8PRhcEn3czEjhAO9o"
+        crossorigin="anonymous"></script>
+</body>
+
+</html>

--- a/changelogs/index.html
+++ b/changelogs/index.html
@@ -67,7 +67,7 @@
                         <a class="nav-link" href="/faq">FAQ</a>
                     </li>
                     <li class="nav-item active">
-                        <a class="nav-link">Changelogs <span class="sr-only">(current)</span></a>
+                        <a class="nav-link" href="#">Changelogs <span class="sr-only">(current)</span></a>
                     </li>
                 </ul>
                 <span class="navbar-text">

--- a/changelogs/index.html
+++ b/changelogs/index.html
@@ -91,7 +91,7 @@
         </section>
 
         <section class="text-center">
-            <h3>Changelogs</h3>
+            <h3>Changelogs (Stable)</h3>
             <p>Below can you find the current Changelogs of 5zig.</p>
             
             <h3><a href="3.13.0">3.13.0</a></h3>

--- a/downloads/index.html
+++ b/downloads/index.html
@@ -55,7 +55,7 @@
                         <a class="nav-link" href="/">Home</a>
                     </li>
                     <li class="nav-item active">
-                        <a class="nav-link" href="#">Downloads <span class="sr-only">(current)</span></a>
+                        Downloads <span class="sr-only">(current)</span>
                     </li>
                     <li class="nav-item">
                         <a class="nav-link" href="https://secure.5zigreborn.eu/panel">Panel</a>
@@ -65,6 +65,9 @@
                     </li>
                     <li class="nav-item">
                         <a class="nav-link" href="/faq">FAQ</a>
+                    </li>
+                    <li class="nav-item">
+                        <a class="nav-link" href="/changelogs">Changelogs</a>
                     </li>
                 </ul>
                 <span class="navbar-text">

--- a/downloads/index.html
+++ b/downloads/index.html
@@ -55,7 +55,7 @@
                         <a class="nav-link" href="/">Home</a>
                     </li>
                     <li class="nav-item active">
-                        Downloads <span class="sr-only">(current)</span>
+                        <a class="nav-link" href="#">Downloads <span class="sr-only">(current)</span></a>
                     </li>
                     <li class="nav-item">
                         <a class="nav-link" href="https://secure.5zigreborn.eu/panel">Panel</a>

--- a/faq/index.html
+++ b/faq/index.html
@@ -64,7 +64,7 @@
                         <a class="nav-link" href="https://status.5zigreborn.eu">Status</a>
                     </li>
                     <li class="nav-item active">
-                        <a class="nav-link">FAQ <span class="sr-only">(current)</span></a>
+                        <a class="nav-link" href="#">FAQ <span class="sr-only">(current)</span></a>
                     </li>
                 </ul>
                 <span class="navbar-text">

--- a/faq/index.html
+++ b/faq/index.html
@@ -64,7 +64,7 @@
                         <a class="nav-link" href="https://status.5zigreborn.eu">Status</a>
                     </li>
                     <li class="nav-item active">
-                        <a class="nav-link" href="#">FAQ <span class="sr-only">(current)</span></a>
+                        <a class="nav-link">FAQ <span class="sr-only">(current)</span></a>
                     </li>
                 </ul>
                 <span class="navbar-text">

--- a/faq/index.html
+++ b/faq/index.html
@@ -66,6 +66,9 @@
                     <li class="nav-item active">
                         <a class="nav-link" href="#">FAQ <span class="sr-only">(current)</span></a>
                     </li>
+                    <li class="nav-item">
+                        <a class="nav-link" href="/changelogs">Changelogs</a>
+                    </li>
                 </ul>
                 <span class="navbar-text">
                     <a href="https://www.patreon.com/bePatron?u=21831307" style="height:37px"

--- a/index.html
+++ b/index.html
@@ -52,7 +52,7 @@
       <div class="collapse navbar-collapse" id="navbarSupportedContent">
         <ul class="navbar-nav mr-auto">
           <li class="nav-item active">
-            <a class="nav-link" href="#">Home <span class="sr-only">(current)</span></a>
+            Home <span class="sr-only">(current)</span>
           </li>
           <li class="nav-item">
             <a class="nav-link" href="downloads/">Downloads</a>
@@ -65,6 +65,9 @@
           </li>
           <li class="nav-item">
             <a class="nav-link" href="/faq">FAQ</a>
+          </li>
+          <li class="nav-item">
+            <a class="nav-link" href="/changelogs">Changelogs</a>
           </li>
         </ul>
         <span class="navbar-text">

--- a/index.html
+++ b/index.html
@@ -52,7 +52,7 @@
       <div class="collapse navbar-collapse" id="navbarSupportedContent">
         <ul class="navbar-nav mr-auto">
           <li class="nav-item active">
-            Home <span class="sr-only">(current)</span>
+            <a class="nav-link">Home <span class="sr-only">(current)</span></a>
           </li>
           <li class="nav-item">
             <a class="nav-link" href="downloads/">Downloads</a>

--- a/index.html
+++ b/index.html
@@ -52,7 +52,7 @@
       <div class="collapse navbar-collapse" id="navbarSupportedContent">
         <ul class="navbar-nav mr-auto">
           <li class="nav-item active">
-            <a class="nav-link">Home <span class="sr-only">(current)</span></a>
+            <a class="nav-link" href="#">Home <span class="sr-only">(current)</span></a>
           </li>
           <li class="nav-item">
             <a class="nav-link" href="downloads/">Downloads</a>


### PR DESCRIPTION
This PR adds a Changelogs page for people to find.

It basically adds a new entry called "Changelogs" into the nav bar and has a page that links to the pages located within the changelogs folder.

A live-preview of this can be found at https://github.andre601.com/5zig-reborn.github.io/

**NOTE**: Due to how the domain stuff is handled on the website can you not just use the button, as this would turn the link into https://github.andre601.com/changelogs, which doesn't exists...
So you have to manually append "changelogs" to the URL. (https://github.andre601.com/5zig-reborn.github.io/changelogs/)