### PR TITLE
"5zig Reborn" button in navbar

### DIFF
--- a/changelogs/index.html
+++ b/changelogs/index.html
@@ -43,7 +43,7 @@
 <body>
     <header>
         <nav class="navbar navbar-expand-lg navbar-dark bg-dark">
-            <a class="navbar-brand" href="#">5zig Reborn</a>
+            <a class="navbar-brand" href="/">5zig Reborn</a>
             <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarSupportedContent"
                 aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
                 <span class="navbar-toggler-icon"></span>

--- a/downloads/index.html
+++ b/downloads/index.html
@@ -47,7 +47,7 @@
 <body>
     <header>
         <nav class="navbar navbar-expand-lg navbar-dark bg-dark">
-            <a class="navbar-brand" href="#">5zig Reborn</a>
+            <a class="navbar-brand" href="/">5zig Reborn</a>
             <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarSupportedContent"
                 aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
                 <span class="navbar-toggler-icon"></span>

--- a/faq/index.html
+++ b/faq/index.html
@@ -43,7 +43,7 @@
 <body>
     <header>
         <nav class="navbar navbar-expand-lg navbar-dark bg-dark">
-            <a class="navbar-brand" href="#">5zig Reborn</a>
+            <a class="navbar-brand" href="/">5zig Reborn</a>
             <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarSupportedContent"
                 aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
                 <span class="navbar-toggler-icon"></span>


### PR DESCRIPTION
I changed the "brand button", because the expected behavior of the brand button usually is to take the user to the main page. In addition, taking them to the top doesn't work in this scenario, because the header doesn't stick to the top of the screen and isn't accessible after scrolling down.